### PR TITLE
Add new step for PR checks

### DIFF
--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -170,9 +170,29 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # the name must be identical to the one received by the real job
           sha: ${{ inputs.prHeadSha }}
-          name: "build, test, package"
+          name: "Build, test, publish / All succeeded"
           status: "completed"
           conclusion: "success"
+
+  pr-succeeded:
+    # simple no-op job to use as step for checks for PR checks
+    name: All succeeded
+    needs: # TODO - check what jobs need adding here
+      - build
+      - test-azdo
+      - test-gh-run-args
+      - test-gh-build-args
+      - test-gh-dockerfile-context
+      - test-gh-feature-docker-from-docker
+      - test-gh-docker-from-docker-non-root
+      - test-gh-docker-from-docker-root
+      - test-gh-skip-user-update
+      - test-compose-features
+    runs-on: ubuntu-latest
+    steps:
+      - name: Simple step
+        run: |
+          echo Done!
 
   release:
     name: Create release

--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -61,7 +61,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # the name must be identical to the one received by the real job
           sha: ${{ steps.check_command.outputs.prHeadSha }}
-          name: "build, test, package"
+          name: "Build, test, publish / All succeeded"
           status: "completed"
           conclusion: "success"
 


### PR DESCRIPTION
Add a new step that can be triggered by branch and PR builds. The goal is to enable branch builds to mark the checks as passing for times when pr-bot builds aren't usable (e.g. workflow changes)