### PR TITLE
Add automatically triggered PR build

### DIFF
--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -10,6 +10,11 @@ on:
         default: ''
         type: string
         required: false
+      runFullTests:
+        description: tick to run the full tests, untick to run tests without credentials
+        default: true
+        type: boolean
+        required: false
 
 jobs:
   build-test-publish:
@@ -18,6 +23,8 @@ jobs:
     with:
       release: false
       prNumber: ${{ github.event.inputs.prNumber }}
+      # despite the runFullTests input being a boolean, we seem to get a string below!
+      runFullTests: ${{ github.event.inputs.runFullTests == 'true' }}
     secrets:
       AZDO_TOKEN: ${{ secrets.AZDO_TOKEN }}
       MARKETPLACE_TOKEN: ${{ secrets.MARKETPLACE_TOKEN }}

--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -20,6 +20,11 @@ on:
           running on a comment trigger), pass the PR's head SHA commit here
         type: string
         required: false
+      runFullTests:
+        description: true to run the full tests, false to run tests without credentials
+        default: true
+        type: boolean
+        required: false
       release:
         type: boolean
         description: indicates whether to make a release
@@ -57,6 +62,7 @@ jobs:
       version_short: ${{ steps.build.outputs.version_short }}
       version: ${{ steps.build.outputs.version }}
       image_tag: ${{ steps.set_image_tag.outputs.image_tag }}
+      image_push_option: ${{ steps.set_image_push_option.outputs.image_push_option }}
       build_number: ${{ steps.build_number.outputs.build_number }}
     steps:
       - name: Checkout
@@ -70,7 +76,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - id: set_image_push_option
+        name: Set image push option
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // if running full tests then use the filter option, for the dev container action
+            // else, set to never to avoid pushing (as we're likely running without secrets)
+
+            const pushOption = ${{ inputs.runFullTests }} ? 'filter' : 'never';
+            console.log(`Setting image_push_option=${pushOption}`);
+            core.setOutput("image_push_option", pushOption);
+        
       - name: Login to GitHub Container Registry
+        if: ${{ steps.set_image_push_option.outputs.image_push_option == 'filter' }}
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
@@ -121,7 +140,8 @@ jobs:
           runCmd: |
             echo "Starting"
             ./scripts/build-test-package.sh
-          eventFilterForPush: | # allow image push on pull_request
+          push: ${{ steps.set_image_push_option.outputs.image_push_option }}
+          eventFilterForPush: |
             push
             pull_request
           env: |
@@ -317,6 +337,7 @@ jobs:
     name: Run AzDO test
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ needs.build.outputs.image_push_option == 'filter' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -402,6 +423,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to GitHub Container Registry
+        if: ${{ needs.build.outputs.image_push_option == 'filter' }}
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
@@ -415,7 +437,8 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/run-args
           runCmd: echo $HOSTNAME && [[ $HOSTNAME == "my-host" ]]
           imageTag: ${{ needs.build.outputs.image_tag }}
-          eventFilterForPush: | # allow image push on pull_request
+          push: ${{ needs.build.outputs.image_push_option }}
+          eventFilterForPush: |
             push
             pull_request
 
@@ -437,6 +460,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: ${{ needs.build.outputs.image_push_option == 'filter' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -449,7 +473,8 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/build-args
           runCmd: echo $BUILD_ARG_TEST && [[ $BUILD_ARG_TEST == "Hello build-args!" ]]
           imageTag: ${{ needs.build.outputs.image_tag }}
-          eventFilterForPush: | # allow image push on pull_request
+          push: ${{ needs.build.outputs.image_push_option }}
+          eventFilterForPush: |
             push
             pull_request
 
@@ -471,6 +496,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: ${{ needs.build.outputs.image_push_option == 'filter' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -483,7 +509,8 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/dockerfile-context
           runCmd: /tmp/dummy.sh
           imageTag: ${{ needs.build.outputs.image_tag }}
-          eventFilterForPush: | # allow image push on pull_request
+          push: ${{ needs.build.outputs.image_push_option }}
+          eventFilterForPush: |
             push
             pull_request
 
@@ -505,6 +532,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: ${{ needs.build.outputs.image_push_option == 'filter' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -517,7 +545,8 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/feature-docker-from-docker
           runCmd: make docker-build
           imageTag: ${{ needs.build.outputs.image_tag }}
-          eventFilterForPush: | # allow image push on pull_request
+          push: ${{ needs.build.outputs.image_push_option }}
+          eventFilterForPush: |
             push
             pull_request
 
@@ -539,6 +568,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: ${{ needs.build.outputs.image_push_option == 'filter' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -551,7 +581,8 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/docker-from-docker-non-root
           runCmd: make docker-build
           imageTag: ${{ needs.build.outputs.image_tag }}
-          eventFilterForPush: | # allow image push on pull_request
+          push: ${{ needs.build.outputs.image_push_option }}
+          eventFilterForPush: |
             push
             pull_request
 
@@ -573,6 +604,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: ${{ needs.build.outputs.image_push_option == 'filter' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -585,7 +617,8 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/docker-from-docker-root
           runCmd: make docker-build
           imageTag: ${{ needs.build.outputs.image_tag }}
-          eventFilterForPush: | # allow image push on pull_request
+          push: ${{ needs.build.outputs.image_push_option }}
+          eventFilterForPush: |
             push
             pull_request
 
@@ -607,6 +640,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 
+        if: ${{ needs.build.outputs.image_push_option == 'filter' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -626,7 +660,8 @@ jobs:
             echo "Group ID: $group_id"
             [[ $user_id == 1000 ]] && [[ $group_id == 1000 ]]
           imageTag: ${{ needs.build.outputs.image_tag }}
-          eventFilterForPush: | # allow image push on pull_request
+          push: ${{ needs.build.outputs.image_push_option }}
+          eventFilterForPush: |
             push
             pull_request
 
@@ -649,6 +684,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
+        if: ${{ needs.build.outputs.image_push_option == 'filter' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -661,6 +697,7 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/compose-features
           runCmd: go version
           imageTag: ${{ needs.build.outputs.image_tag }}
-          eventFilterForPush: | # allow image push on pull_request
+          push: ${{ needs.build.outputs.image_push_option }}
+          eventFilterForPush: |
             push
             pull_request

--- a/.github/workflows/pr_auto.yml
+++ b/.github/workflows/pr_auto.yml
@@ -1,0 +1,23 @@
+---
+name: pr_auto
+# This workflow is triggered automatically for pull requests and runs tests without credentials
+# I.e. doesn't validate image caching, doesn't perform tests in Azure DevOps.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - README.md
+      - 'docs/**'
+
+jobs:
+  build-test:
+    name: "Build, test, publish"
+    uses: ./.github/workflows/ci_common.yml
+    with:
+      prNumber: ${{ github.event.pull_request.number }}
+      release: false
+      runFullTests: false
+    secrets:
+      AZDO_TOKEN: ${{ secrets.AZDO_TOKEN }}
+      MARKETPLACE_TOKEN: ${{ secrets.MARKETPLACE_TOKEN }}

--- a/maintainers.md
+++ b/maintainers.md
@@ -6,7 +6,7 @@ This document is targetted at maintainers of the project.
 
 **Notes**
 - these commands are not immediate - you need to wait for the GitHub action that performs the task to start up.
-- builds triggered via these commands will use the workflow definitions from `main`.
+- builds triggered via these commands will use the workflow definitions from `main`. To test workflow changes before merging to `main`, push the changes to a branch in the repo and use the `ci_branch` workflow.
 
 These commands can only be run when commented by a user who is identified as a repo collaborator (see [granting access to run commands](#granting-access-to-run-commands))
 
@@ -41,3 +41,9 @@ This is intended to be used in scenarios where running the tests for a PR doesn'
 ## Granting access to run commands
 
 Currently, the GitHub API to determine whether a user is a collaborator doesn't seem to respect permissions that a user is granted via a group. As a result, users need to be directly granted `write` permission in the repo to be able to run the comment bot commands.
+
+## Implementation notes
+
+The pr-bot workflow is in `.github/workflows/pr-bot.yml`. Most of the logic for handling commands is split out into `.github/scripts/build.js` and there are accompanying tests in the same folder (`yarn install && yarn test` to run tests).
+
+The `build.js` script parses the comment text and sets various output values that are then used to control the behaviour of the remaining workflow. The core of the workflow is in `ci_common.yml` and is re-used between the pr-bot and `ci_main.yml` (triggered for merges into `main` to make a release).


### PR DESCRIPTION
Only run steps that don't need credentials to give automated feedback on PRs.
The full test/validation run can then be triggered via a `/test` comment on the PR from maintainers.