### PR TITLE
Fix auto-triggered PR build

### DIFF
--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -68,7 +68,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          persist-credentials: false
           # if the following value is missing (i.e. not triggered via comment workflow)
           # then the default checkout will apply
           ref: ${{ inputs.prRef }}
@@ -100,6 +99,8 @@ jobs:
       # but this got outside the limit for AzDO extensions (0 to 2147483647)
       - name: Generate build number
         id: build_number
+        # only run this if we are going to run the AzDO publishing
+        if: ${{ steps.set_image_push_option.outputs.image_push_option == 'filter' }}
         uses: einaregilsson/build-number@v3 
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/build-test-package.sh
+++ b/scripts/build-test-package.sh
@@ -45,7 +45,9 @@ cd "$script_dir/.."
 git checkout azdo-task/vss-extension.json
 git checkout azdo-task/DevcontainersCi/task.json
 # The GH action to generate the build number leaves a BUILD_NUMBER file behind
-rm BUILD_NUMBER
+if [[ -f BUILD_NUMBER ]]; then
+    rm BUILD_NUMBER
+fi
 if [[ -n $(git status --short) ]]; then
     echo "*** There are unexpected changes in the working directory (see git status output below)"
     echo "*** Ensure you have run scripts/build-local.sh"


### PR DESCRIPTION
Skip version number generation (used in AzDO tests that aren't included in the aut-triggered build)