### PR TITLE
Pull if condition on to same line

### DIFF
--- a/.github/workflows/pr-bot.yml
+++ b/.github/workflows/pr-bot.yml
@@ -67,8 +67,7 @@ jobs:
 
   run_test:
     needs: [pr_comment]
-    if: |
-      ${{ needs.pr_comment.outputs.command == 'run-tests' }}
+    if: ${{ needs.pr_comment.outputs.command == 'run-tests' }}
     name: build-test
     uses: ./.github/workflows/ci_common.yml
     with:


### PR DESCRIPTION
It seems that the pr-bot is misbehaving. E.g. in this execution, you can see `command: none` (https://github.com/devcontainers/ci/runs/7412566376?check_suite_focus=true#step:3:19), but the workflow still runs the tests.

In testing, conditions split onto a separate line with a pipe result in a true condition so this PR brings the `if` into a single line
