### PR TITLE
Improve docs, update names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,53 @@
-# devcontainers/ci
+# Dev Container Build and Run (devcontainers/ci)
 
-devcontainers/ci contains a GitHub action and Azure DevOps task aimed at making it easier to re-use a [development container](https://github.com/devcontainers/spec) in a GitHub workflow or Azure DevOps pipeline.
+The Dev Container Build and Run GitHub Action is aimed at making it easier to re-use [Dev Containers](https://containers.dev) in a GitHub workflow. The Action supports both using a Dev Container to run commands for CI, testing, and more along with pre-building Dev Container image. Dev Container image building supports [Dev Container Features](https://containers.dev/implementors/features/#devcontainer-json-properties) and automatically places Dev Container [metadata on an image](https://containers.dev/implementors/spec/#image-metadata) label for simplified use.
 
-This project builds on top of [@devcontainers/cli](https://www.npmjs.com/package/@devcontainers/cli)
+An similar [Azure DevOps Task](./docs/azure-devops-task.md) is also available!
 
+Note that this project builds on top of [@devcontainers/cli](https://www.npmjs.com/package/@devcontainers/cli) which can be used in other automation systems.
 
 ## GitHub Action
+The examples below shows usage of the GitHub Action - see the [GitHub Action documentation](./docs/github-action.md) for more details.
 
-The example below shows usage of the GitHub Action - see the [GitHub Action documentation](./docs/github-action.md) for more details:
+> **NOTE:** This Action is not currently capable of taking advantage of pre-built Codespaces. However, pre-built images are supported.
 
+
+**Pre-building an image:**
 
 ```yaml
-- name: Build and run dev container task
+- name: Pre-build dev container image
   uses: devcontainers/ci@v0.2
   with:
     imageName: ghcr.io/example/example-devcontainer
+    cacheFrom: ghcr.io/example/example-devcontainer
+    push: true
+```
+
+**Using a dev container for a CI build:**
+
+```yaml
+- name: Run make ci-build in dev container
+  uses: devcontainers/ci@v0.2
+  with:    
+    # [Optional] Even if you're not directly referencing a pre-built image,
+    # you can still use the image as a cache for your Dockerfile build.
+    cacheFrom: ghcr.io/example/example-devcontainer
+
+    push: never
     runCmd: make ci-build
 ```
 
-## Azure DevOps Task
-
-The example below shows usage of the Azure DevOps Task - see the [Azure DevOps Task documentation](./docs/azure-devops-task.md) for more details:
+**Both at once:**
 
 ```yaml
-- task: DevcontainersCI@0
-  inputs:
-    imageName: 'yourregistry.azurecr.io/example-dev-container'
-    runCmd: 'make ci-build'
-    sourceBranchFilterForPush: refs/heads/main
+- name: Pre-build image and run make ci-build in dev container
+  uses: devcontainers/ci@v0.2
+  with:
+    imageName: ghcr.io/example/example-devcontainer
+    cacheFrom: ghcr.io/example/example-devcontainer
+    push: true
+    runCmd: make ci-build
 ```
-
 
 ## CHANGELOG
 
@@ -37,10 +55,10 @@ The example below shows usage of the Azure DevOps Task - see the [Azure DevOps T
 
 This version updates the implementation to use [@devcontainers/cli](https://www.npmjs.com/package/@devcontainers/cli).
 
-This brings many benefits around compatibility with VS Code Dev Containers. One key area is that [container-features](https://code.visualstudio.com/docs/remote/containers#_dev-container-features-preview) can now be used in CI.
+This brings many benefits around compatibility with Dev Containers. One key area is that [container-features](https://code.visualstudio.com/docs/remote/containers#_dev-container-features-preview) can now be used in CI.
 
-In theory, docker-compose based dev containers should also work however these are currently untested and image caching is blocked on [this issue](https://github.com/devcontainers/cli/issues/10)
+In theory, docker-compose based Dev Containers should also work however these are currently untested and image caching is blocked on [this issue](https://github.com/devcontainers/cli/issues/10)
 
 ### Version 0.1.x
 
-0.1.x versions were the initial version of the action/task and attempted to mimic the behaviour of dev containers with manual `docker` commands
+0.1.x versions were the initial version of the action/task and attempted to mimic the behaviour of Dev Containers with manual `docker` commands

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'devcontainers-ci'
-description: 'Action to simplify using VS Code dev containers in GitHub workflows'
+name: 'Dev Container Build and Run Action'
+description: 'Action to simplify using Dev Containers (https://containers.dev) in GitHub workflows'
 author: 'devcontainers'
 branding:
   color: purple
@@ -40,7 +40,7 @@ inputs:
   skipContainerUserIdUpdate:
     required: false
     default: false
-    description: For non-root dev containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)
+    description: For non-root Dev Containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)
   userDataFolder:
     required: false
     description: Some steps for building the dev container (e.g. container-features) require generating additional build files. To aid docker build cache re-use, you can use this property to set the path that these files will be generated under and use the actions/cache action to cache that folder across runs

--- a/azdo-task/DevcontainersCi/package.json
+++ b/azdo-task/DevcontainersCi/package.json
@@ -2,7 +2,7 @@
   "name": "ci",
   "version": "0.0.0",
   "private": true,
-  "description": "Azure DevOps task for building and running VS Code dev containers",
+  "description": "Azure DevOps task for building and running Dev Containers (https://containers.dev)",
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc --build",

--- a/azdo-task/DevcontainersCi/task.json
+++ b/azdo-task/DevcontainersCi/task.json
@@ -3,7 +3,7 @@
   "id": "d784888b-f54b-4926-a8d1-3a159d2de8e0",
   "name": "DevcontainersCi",
   "friendlyName": "Devcontainers CI Task",
-  "description": "Build and run VS Code dev containers in Azure DevOps Pipelines",
+  "description": "Build and run Dev Containers (https://containers.dev) in Azure DevOps Pipelines",
   "author": "Devcontainers",
   "helpMarkDown": "",
   "category": "Build",
@@ -87,7 +87,7 @@
     {
       "name": "skipContainerUserIdUpdate",
       "type": "boolean",
-      "label": "For non-root dev containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)",
+      "label": "For non-root Dev Containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)",
       "required": false,
       "defaultValue": false
 

--- a/azdo-task/README.md
+++ b/azdo-task/README.md
@@ -1,10 +1,9 @@
-# DevcontainersCi
+# Dev Container Build and Run Task
 
-DevcontainersCi is an Azure DevOps task aimed at making it easier to re-use a [Visual Studio Code dev container](https://code.visualstudio.com/) in an Azure DevOps pipeline.
+The Dev Container Build and Run Azure DevOps task aimed at making it easier to re-use a [Dev Container](https://containers.dev) in an Azure DevOps pipeline. It supports both using a Dev Container to run commands for CI, testing, and more along with pre-building Dev Container image. Dev Container image building supports [Dev Container Features](https://containers.dev/implementors/features/#devcontainer-json-properties) and automatically places Dev Container [metadata on an image](https://containers.dev/implementors/spec/#image-metadata) label for simplified use.
+
 
 ## Getting Started
-
-
 
 The simplest example of using the action is shown below:
 
@@ -77,7 +76,7 @@ In the example above, the devcontainer-build-run will perform the following step
 | pushOnFailedBuild         | false    | If `false` (default), only push if the build is successful. Set to true to push on failed builds                                                                                                                                                                 |
 | sourceBranchFilterForPush | false    | Allows you to limit which branch's builds are pushed to the registry (only specified branches are allowed to push). If empty, all branches are allowed                                                                                                           |
 | buildReasonsForPush       | false    | Allows you to limit the Build.Reason values that are allowed to push to the registry. Defaults to Manual, IndividualCI, BatchedCI. See https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&viewFallbackFrom=vsts&tabs=yaml |
-| skipContainerUserIdUpdate | false    | For non-root dev containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)                                              |
+| skipContainerUserIdUpdate | false    | For non-root Dev Containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)                                              |
 | cacheFrom                 | false    | Specify additional images to use for build caching                                                                                                                                                                                                               |
 
 ## Outputs

--- a/azdo-task/vss-extension.json
+++ b/azdo-task/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "ci",
-    "name": "Devcontainers CI",
+    "name": "Dev Container Build and Run Task",
     "version": "0.2.0",
     "publisher": "devcontainers",
     "targets": [
@@ -9,13 +9,13 @@
             "id": "Microsoft.VisualStudio.Services"
         }
     ],
-    "description": "Extension for building and running VS Code Dev Containers in Azure DevOps Pipelines",
+    "description": "Extension for building and running Dev Containers (https://containers.dev) in Azure DevOps Pipelines",
     "categories": [
         "Azure Pipelines"
     ],
     "tags": [
         "Visual Studio Extensions",
-        "Dev containers",
+        "Dev Containers",
         "Devcontainers"
     ],
     "links": {

--- a/docs/azure-devops-task.md
+++ b/docs/azure-devops-task.md
@@ -1,6 +1,6 @@
-# DevcontainersCi
+# Dev Container Build and Run Task
 
-DevcontainersCi is an Azure DevOps task aimed at making it easier to re-use a [Visual Studio Code dev container](https://code.visualstudio.com/) in an Azure DevOps pipeline.
+The Dev Container Build and Run Azure DevOps task aimed at making it easier to re-use a [Dev Container](https://containers.dev) in an Azure DevOps pipeline. It supports both using a Dev Container to run commands for CI, testing, and more along with pre-building Dev Container image. Dev Container image building supports [Dev Container Features](https://containers.dev/implementors/features/#devcontainer-json-properties) and automatically places Dev Container [metadata on an image](https://containers.dev/implementors/spec/#image-metadata) label for simplified use.
 
 ## Getting Started
 
@@ -77,7 +77,7 @@ In the example above, the devcontainer-build-run will perform the following step
 | pushOnFailedBuild         | false    | If `false` (default), only push if the build is successful. Set to true to push on failed builds                                                                                                                                                                 |
 | sourceBranchFilterForPush | false    | Allows you to limit which branch's builds are pushed to the registry (only specified branches are allowed to push). If empty, all branches are allowed                                                                                                           |
 | buildReasonsForPush       | false    | Allows you to limit the Build.Reason values that are allowed to push to the registry. Defaults to Manual, IndividualCI, BatchedCI. See https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&viewFallbackFrom=vsts&tabs=yaml |
-| skipContainerUserIdUpdate | false    | For non-root dev containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)                                              |
+| skipContainerUserIdUpdate | false    | For non-root Dev Containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)                                              |
 | cacheFrom                 | false    | Specify additional images to use for build caching                                                                                                                                                                                                               |
 
 ## Outputs

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,6 +1,8 @@
-# devcontainers/ci GitHub Action
+# Dev Container Build and Run GitHub Action
 
-devcontainer-build-run is a GitHub action aimed at making it easier to re-use a [Visual Studio Code dev container](https://code.visualstudio.com/) in a GitHub workflow.
+The Dev Container Build and Run GitHub Action is aimed at making it easier to re-use [Dev Containers](https://containers.dev) in a GitHub workflow. The Action supports both using a Dev Container to run commands for CI, testing, and more along with pre-building Dev Container image. Dev Container image building supports [Dev Container Features](https://containers.dev/implementors/features/#devcontainer-json-properties) and automatically places Dev Container [metadata on an image](https://containers.dev/implementors/spec/#image-metadata) label for simplified use.
+
+> **NOTE:** This Action cannot currently take advantage of [pre-built Codespaces](https://docs.github.com/en/codespaces/prebuilding-your-codespaces/about-github-codespaces-prebuilds). However, you can create or use pre-built container images are supported.
 
 ##  Getting Started
 
@@ -59,7 +61,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and run dev container task
+      - name: Build and run Dev Container task
         uses: devcontainers/ci@v0.2
         with:
           # Change this to point to your image name
@@ -77,7 +79,48 @@ In the example above, the devcontainer-build-run will perform the following step
 2. Run the dev container with the `make ci-build` command specified in the `runCmd` input
 3. If the run succeeds (and we're not building from a PR branch) then push the image to the container registry. This enables future image builds in step 1 to use the image layers as a cache to improve performance
 
-The [`devcontainers/ci` action](https://github.com/marketplace/actions/devcontainer-build-run) uses Docker BuildKit to perform the Docker builds as this has support for storing layer cache metadata with the image.  This is installed by default on hosted runners but you can use the [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action) to install this on your own runners.
+The [`devcontainers/ci` action](https://github.com/marketplace/actions/devcontainers-ci) uses Docker BuildKit to perform the Docker builds as this has support for storing layer cache metadata with the image.  This is installed by default on hosted runners but you can use the [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action) to install this on your own runners.
+
+
+### Other examples
+
+**Pre-building an image:**
+
+```yaml
+- name: Pre-build dev container image
+  uses: devcontainers/ci@v0.2
+  with:
+    imageName: ghcr.io/example/example-devcontainer
+    cacheFrom: ghcr.io/example/example-devcontainer
+    push: true
+```
+
+**Using a dev container for a CI build:**
+
+```yaml
+- name: Run make ci-build in dev container
+  uses: devcontainers/ci@v0.2
+  with:    
+    # [Optional] Even if you're not directly referencing a pre-built image,
+    # you can still use the image as a cache for your Dockerfile build.
+    cacheFrom: ghcr.io/example/example-devcontainer
+
+    push: never
+    runCmd: make ci-build
+```
+
+**Both at once:**
+
+```yaml
+- name: Pre-build image and run make ci-build in dev container
+  uses: devcontainers/ci@v0.2
+  with:
+    imageName: ghcr.io/example/example-devcontainer
+    cacheFrom: ghcr.io/example/example-devcontainer
+    push: true
+    runCmd: make ci-build
+```
+
 
 ## Inputs
 
@@ -92,7 +135,7 @@ The [`devcontainers/ci` action](https://github.com/marketplace/actions/devcontai
 | push                      | false    | Control when images are pushed. Options are `never`, `filter`, `always`. For `filter`, images are pushed if the `refFilterForPush` and `eventFilterForPush` conditions are met. Defaults to `filter` if `imageName` is set, `never` otherwise. |
 | refFilterForPush          | false    | Set the source branches (e.g. `refs/heads/main`) that are allowed to trigger a push of the dev container image. Leave empty to allow all (default)                                                                                             |
 | eventFilterForPush        | false    | Set the event names (e.g. `pull_request`, `push`) that are allowed to trigger a push of the dev container image. Defaults to `push`. Leave empty for all                                                                                       |
-| skipContainerUserIdUpdate | false    | For non-root dev containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)                            |
+| skipContainerUserIdUpdate | false    | For non-root Dev Containers (i.e. where `remoteUser` is specified), the action attempts to make the container user UID and GID match those of the host user. Set this to true to skip this step (defaults to false)                            |
 | cacheFrom                 | false    | Specify additional images to use for build caching                                                                                                                                                                                             |
 
 ## Outputs

--- a/github-action/package.json
+++ b/github-action/package.json
@@ -2,7 +2,7 @@
   "name": "devcontainer-build-run",
   "version": "0.0.0",
   "private": true,
-  "description": "GitHub action for building and running VS Code dev containers",
+  "description": "Action to simplify using Dev Containers (https://containers.dev) in GitHub workflows",
   "main": "lib/main.js",
   "scripts": {
     "tsc-version": "tsc --version",


### PR DESCRIPTION
This PR improves docs better aligns naming for the GitHub Action and Azure DevOps tasks and scrubs "VS Code" from the content given the Action/Task is in the devcontainers org.

Currently the /README.md file is only used for the GitHub Action, so I removed direct information about the Azure DevOps task since that looks strange in the marketplace.  I then updated 

I tweaked the name of the Action to "Dev Containers Build and Run" since that's less confusing given the existing "Dev Container Features" and  "Dev Container Publish" tasks.

I also added a note that the Action cannot take advantage of Codespace pre-builds since this has come up more than once already.