### PR TITLE
Reduce redundancy in README, push flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Here are three examples of using the Action for common scenarios. See the [docum
   with:
     imageName: ghcr.io/example/example-devcontainer
     cacheFrom: ghcr.io/example/example-devcontainer
-    push: true
+    push: always
 ```
 
 **Using a Dev Container for a CI build:**
@@ -45,7 +45,7 @@ Here are three examples of using the Action for common scenarios. See the [docum
   with:
     imageName: ghcr.io/example/example-devcontainer
     cacheFrom: ghcr.io/example/example-devcontainer
-    push: true
+    push: always
     runCmd: make ci-build
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Dev Container Build and Run (devcontainers/ci)
 
-The Dev Container Build and Run GitHub Action is aimed at making it easier to re-use [Dev Containers](https://containers.dev) in a GitHub workflow. The Action supports using a Dev Container to run commands for CI, testing, and more, along with pre-building Dev Container image. Dev Container image building supports [Dev Container Features](https://containers.dev/implementors/features/#devcontainer-json-properties) and automatically places Dev Container [metadata on an image](https://containers.dev/implementors/spec/#image-metadata) label for simplified use.
+The Dev Container Build and Run GitHub Action is aimed at making it easier to re-use [Dev Containers](https://containers.dev) in a GitHub workflow. The Action supports using a Dev Container to run commands for CI, testing, and more, along with pre-building a Dev Container image. Dev Container image building supports [Dev Container Features](https://containers.dev/implementors/features/#devcontainer-json-properties) and automatically places Dev Container [metadata on an image](https://containers.dev/implementors/spec/#image-metadata) label for simplified use.
+
+> **NOTE:** The Action is not currently capable of taking advantage of pre-built Codespaces. However, pre-built images are supported.
 
 A similar [Azure DevOps Task](./docs/azure-devops-task.md) is also available!
 
 Note that this project builds on top of [@devcontainers/cli](https://www.npmjs.com/package/@devcontainers/cli) which can be used in other automation systems.
 
-## GitHub Action
-The examples below show usage of the GitHub Action - see the [GitHub Action documentation](./docs/github-action.md) for more details.
-
-> **NOTE:** This Action is not currently capable of taking advantage of pre-built Codespaces. However, pre-built images are supported.
-
+## Quick start
+Here are three examples of using the Action for common scenarios. See the [documentation](./docs/github-action.md) for more details and a list of available [inputs](./docs/github-action.md#inputs).
 
 **Pre-building an image:**
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -92,7 +92,7 @@ The [`devcontainers/ci` action](https://github.com/marketplace/actions/devcontai
   with:
     imageName: ghcr.io/example/example-devcontainer
     cacheFrom: ghcr.io/example/example-devcontainer
-    push: true
+    push: always
 ```
 
 **Using a Dev Container for a CI build:**
@@ -118,7 +118,7 @@ The [`devcontainers/ci` action](https://github.com/marketplace/actions/devcontai
   with:
     imageName: ghcr.io/example/example-devcontainer
     cacheFrom: ghcr.io/example/example-devcontainer
-    push: true
+    push: always
     runCmd: make ci-build
 ```
 


### PR DESCRIPTION
Had a bit of a "department of redundancy department" thing going in the text.  Some small edits to try to fix.

There also was a scenario where the push flag should be `always` instead of `true`.