### PR TITLE
Set-Output/Set-State Deprecation Update2

### DIFF
--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -150,6 +150,7 @@ jobs:
             IS_CI=1
             IS_PR
             BRANCH
+            GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v2
         name: Create dev AzDO VSIX artifact

--- a/azdo-task/scripts/build-package.sh
+++ b/azdo-task/scripts/build-package.sh
@@ -54,8 +54,8 @@ echo "VERSION_MAJOR=${VERSION_MAJOR}"
 echo "VERSION_MINOR=${VERSION_MINOR}"
 echo "VERSION_PATCH=${VERSION_PATCH}"
 
-echo "::set-output name=version::$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH"
-echo "::set-output name=version_short::$VERSION_MAJOR.$VERSION_MINOR"
+echo "version=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH >> $GITHUB_OUTPUT"
+echo "version_short=$VERSION_MAJOR.$VERSION_MINOR >> $GITHUB_OUTPUT"
 
 if [[ -n $set_patch_version ]]; then
     echo "--set-patch-version specified. Setting extension version to $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH"

--- a/azdo-task/scripts/build-package.sh
+++ b/azdo-task/scripts/build-package.sh
@@ -54,8 +54,8 @@ echo "VERSION_MAJOR=${VERSION_MAJOR}"
 echo "VERSION_MINOR=${VERSION_MINOR}"
 echo "VERSION_PATCH=${VERSION_PATCH}"
 
-echo "version=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH >> $GITHUB_OUTPUT"
-echo "version_short=$VERSION_MAJOR.$VERSION_MINOR >> $GITHUB_OUTPUT"
+echo "version=$VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH" >> $GITHUB_OUTPUT
+echo "version_short=$VERSION_MAJOR.$VERSION_MINOR" >> $GITHUB_OUTPUT
 
 if [[ -n $set_patch_version ]]; then
     echo "--set-patch-version specified. Setting extension version to $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH"


### PR DESCRIPTION
Remaking <https://github.com/devcontainers/ci/pull/181>

Update to handle change for set-output and save-state syntax as per: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I hope this quote placement is correct. I apologize I don't know how to test locally before pushing. 

Why is it being echoed instead of output without echo? 