### PR TITLE
re-enable test `platform_with_runCmd`

### DIFF
--- a/.azure-devops/azure-pipelines.yml
+++ b/.azure-devops/azure-pipelines.yml
@@ -172,39 +172,44 @@ jobs:
       inputs:
         subFolder: github-tests/Dockerfile/build-only
 
-  # Temporarily commented out: https://github.com/devcontainers/ci/issues/198
-  # - job: test_platform_with_runcmd
-  #   displayName: Test with platform and runCmd
-  #   steps:
-  #   - script: |
-  #       docker login -u $ACR_USERNAME -p $ACR_TOKEN $(ACR_NAME).azurecr.io
-  #     displayName: 'Log in to Azure Container Registry'
-  #     env:
-  #       ACR_NAME: $(ACR_NAME)
-  #       ACR_TOKEN: $(ACR_TOKEN)
-  #       ACR_USERNAME: $(ACR_USERNAME)
+  - job: test_platform_with_runcmd
+    displayName: Test with platform and runCmd
+    steps:
+    - script: |
+        docker login -u $ACR_USERNAME -p $ACR_TOKEN $(ACR_NAME).azurecr.io
+      displayName: 'Log in to Azure Container Registry'
+      env:
+        ACR_NAME: $(ACR_NAME)
+        ACR_TOKEN: $(ACR_TOKEN)
+        ACR_USERNAME: $(ACR_USERNAME)
 
-  #   - script: |
-  #       printenv | sort
-  #     env:
-  #       IMAGE_TAG: $(IMAGE_TAG)
+    - script: |
+        printenv | sort
+      env:
+        IMAGE_TAG: $(IMAGE_TAG)
 
-  #   - script: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-  #     displayName: Set up QEMU
+    - script: |
+        sudo apt-get update
+        sudo apt-get -y install skopeo
+        skopeo --version
+      displayName: Update skopeo
 
-  #   - script: docker buildx create --use
-  #     displayName: Set up docker buildx
+    - script: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      displayName: Set up QEMU
 
-  #   - task: DevcontainersCi@0
-  #     inputs:
-  #       imageName: '$(ACR_NAME).azurecr.io/devcontainers-ci/azdo-devcontainer-build-run/test/platform-with-runcmd'
-  #       subFolder: github-tests/Dockerfile/platform-with-runcmd
-  #       platform: linux/amd64,linux/arm64
-  #       runCmd: echo $HOSTNAME && [[ $HOSTNAME == "my-host" ]]
+    - script: docker buildx create --use
+      displayName: Set up docker buildx
 
-  #   - script: |
-  #       echo "'runCmdOutput' value: $runCmdOutput"
-  #       if [["$runCmdOutput" = *my-host*]]; then
-  #         echo "'runCmdOutput' output of test_simple job doesn't contain expected value 'my-host'"
-  #         exit 1
-  #       fi
+    - task: DevcontainersCi@0
+      inputs:
+        imageName: '$(ACR_NAME).azurecr.io/devcontainers-ci/azdo-devcontainer-build-run/test/platform-with-runcmd'
+        subFolder: github-tests/Dockerfile/platform-with-runcmd
+        platform: linux/amd64,linux/arm64
+        runCmd: echo $HOSTNAME && [[ $HOSTNAME == "my-host" ]]
+
+    - script: |
+        echo "'runCmdOutput' value: $runCmdOutput"
+        if [["$runCmdOutput" = *my-host*]]; then
+          echo "'runCmdOutput' output of test_simple job doesn't contain expected value 'my-host'"
+          exit 1
+        fi

--- a/.azure-devops/azure-pipelines.yml
+++ b/.azure-devops/azure-pipelines.yml
@@ -189,10 +189,17 @@ jobs:
         IMAGE_TAG: $(IMAGE_TAG)
 
     - script: |
+        sudo apt purge buildah golang-github-containers-common podman skopeo
+        sudo apt autoremove --purge
+        REPO_URL="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable"
+        source /etc/os-release
+        sudo sh -c "echo 'deb ${REPO_URL}/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
+        sudo wget -qnv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
+        sudo apt-key add Release.key
         sudo apt-get update
-        sudo apt-get -y install skopeo
-        skopeo --version
+        sudo apt-get install skopeo
       displayName: Update skopeo
+
 
     - script: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       displayName: Set up QEMU

--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -921,6 +921,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Update skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install skopeo
+          skopeo --version
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2 
         if: ${{ needs.build.outputs.image_push_option == 'filter' }}

--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -921,11 +921,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      # This can be omitted once runner images have a version of Skopeo > 1.4.1
+      # See https://github.com/containers/skopeo/issues/1874 (and https://github.com/devcontainers/ci/issues/191#issuecomment-1416384710)
       - name: Update skopeo
         run: |
+          sudo apt purge buildah golang-github-containers-common podman skopeo
+          sudo apt autoremove --purge
+          REPO_URL="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable"
+          source /etc/os-release
+          sudo sh -c "echo 'deb ${REPO_URL}/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
+          sudo wget -qnv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
+          sudo apt-key add Release.key
           sudo apt-get update
-          sudo apt-get -y install skopeo
-          skopeo --version
+          sudo apt-get install skopeo
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2 

--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -960,7 +960,7 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/platform-with-runcmd
           platform: linux/amd64,linux/arm64
           runCmd: echo $HOSTNAME && [[ $HOSTNAME == "my-host" ]]
-          push: always ## TODO - revert once tested: ${{ needs.build.outputs.image_push_option }}
+          push: ${{ needs.build.outputs.image_push_option }}
           eventFilterForPush: |
             push
             pull_request

--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -960,8 +960,7 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/platform-with-runcmd
           platform: linux/amd64,linux/arm64
           runCmd: echo $HOSTNAME && [[ $HOSTNAME == "my-host" ]]
-          push: never  # Temporarily suppress push: https://github.com/devcontainers/ci/issues/198
-          # push: ${{ needs.build.outputs.image_push_option }}
+          push: always ## TODO - revert once tested: ${{ needs.build.outputs.image_push_option }}
           eventFilterForPush: |
             push
             pull_request

--- a/github-tests/Dockerfile/platform-with-runcmd/.devcontainer/Dockerfile
+++ b/github-tests/Dockerfile/platform-with-runcmd/.devcontainer/Dockerfile
@@ -10,6 +10,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set env for tracking that we're running in a devcontainer
 ENV DEVCONTAINER=true
 
+USER root
+
+# Configure apt, install packages and general tools
+RUN sudo apt-get update \
+    && sudo apt-get -y install --no-install-recommends apt-utils dialog nano bash-completion sudo bsdmainutils \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && sudo apt-get -y install git iproute2 procps lsb-release figlet build-essential
+
+
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
 # will be updated to match your local UID/GID (when using the dockerFile property).
@@ -23,12 +33,6 @@ RUN \
     mkdir -p ~/.local/bin \
     && echo "export PATH=\$PATH:~/.local/bin" >> ~/.bashrc
 
-# Configure apt, install packages and general tools
-RUN sudo apt-get update \
-    && sudo apt-get -y install --no-install-recommends apt-utils dialog nano bash-completion sudo bsdmainutils \
-    #
-    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && sudo apt-get -y install git iproute2 procps lsb-release figlet build-essential
 
 # Save command line history
 RUN echo "export HISTFILE=/home/$USERNAME/commandhistory/.bash_history" >> "/home/$USERNAME/.bashrc" \


### PR DESCRIPTION
Fixes #198 

TODO
 - once build passes, remove `--remove-signatures` and re-test
 - review `sudo` error workaround
 - skopeo update... turns out it's only in Ubuntu package registries for 20.10 and later but latest AzDO hosted agent is 20.04. https://github.com/containers/skopeo/blob/main/install.md#ubuntu