### PR TITLE
Temporarily suppress push on platform-with-runcmd test

### DIFF
--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -788,7 +788,8 @@ jobs:
           imageName: ghcr.io/devcontainers/ci/tests/platform-with-runcmd
           platform: linux/amd64,linux/arm64
           runCmd: echo $HOSTNAME && [[ $HOSTNAME == "my-host" ]]
-          push: ${{ needs.build.outputs.image_push_option }}
+          push: never  # Temporarily suppress push: https://github.com/devcontainers/ci/issues/198
+          # push: ${{ needs.build.outputs.image_push_option }}
           eventFilterForPush: |
             push
             pull_request


### PR DESCRIPTION
Suppress image push on the `platform-with-runcmd` as a workaround to get main builds working until #198 is resolved.