### PR TITLE
Update to run 'devcontainer exec' without JSON parsing output

### DIFF
--- a/azdo-task/DevcontainersCi/src/main.ts
+++ b/azdo-task/DevcontainersCi/src/main.ts
@@ -152,13 +152,14 @@ export async function runMain(): Promise<void> {
 				}
 			};
 			const execResult = await devcontainer.exec(execArgs, execLog);
-			if (execResult.outcome !== 'success') {
+			if (execResult !== 0) {
 				console.log(
-					`### ERROR: Dev container exec: ${execResult.message} (exit code: ${execResult.code})\n${execResult.description}`,
+					`### ERROR: Dev container exec failed (exit code: ${execResult})`,
 				);
-				task.setResult(TaskResult.Failed, execResult.message);
-			}
-			if (execResult.outcome !== 'success') {
+				task.setResult(
+					TaskResult.Failed,
+					`Dev container exec failed (exit code: ${execResult})`,
+				);
 				return;
 			}
 			if (execLogString.length >= 25000) {

--- a/github-action/src/main.ts
+++ b/github-action/src/main.ts
@@ -177,12 +177,11 @@ export async function runMain(): Promise<void> {
 							execLogString += message;
 						}
 					};
-					const result = await devcontainer.exec(args, execLog);
-					if (result.outcome !== 'success') {
-						core.error(
-							`Dev container exec: ${result.message} (exit code: ${result.code})\n${result.description}`,
-						);
-						core.setFailed(result.message);
+					const exitCode = await devcontainer.exec(args, execLog);
+					if (exitCode !== 0) {
+						const errorMessage = `Dev container exec failed: (exit code: ${exitCode})`;
+						core.error(errorMessage);
+						core.setFailed(errorMessage);
 					}
 					core.setOutput('runCmdOutput', execLogString);
 					if (Buffer.byteLength(execLogString, 'utf-8') > 1000000) {
@@ -190,10 +189,10 @@ export async function runMain(): Promise<void> {
 						execLogString += 'TRUNCATED TO 1 MB MAX OUTPUT SIZE';
 					}
 					core.setOutput('runCmdOutput', execLogString);
-					return result;
+					return exitCode;
 				},
 			);
-			if (execResult.outcome !== 'success') {
+			if (execResult !== 0) {
 				return;
 			}
 		} else {


### PR DESCRIPTION
As discussed in #223, an upcoming change in `devcontainer exec` will mean that it no longer returns a JSON response object via `stdout`. In preparation for that change, this PR modifies the behaviour of the action/task to determine the outcome of `devcontainer exec` solely using the process exit code (which is valid currently as per [this comment](https://github.com/devcontainers/ci/issues/223#issuecomment-1456362374))