### PR TITLE
Revert to latest version of tfx-cli

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,8 +55,7 @@ RUN sudo groupadd docker && sudo usermod -aG docker $USERNAME && newgrp docker
 COPY scripts/act.sh /tmp/
 RUN /bin/bash /tmp/act.sh 0.2.21
 
-# Pin to 0.12.0: https://github.com/microsoft/tfs-cli/issues/427
-RUN sudo npm install -g tfx-cli@0.12.0 
+RUN sudo npm install -g tfx-cli
 
 # azure-cli-no-mount
 COPY scripts/azure-cli.sh /tmp/


### PR DESCRIPTION
Revert [this change](https://github.com/devcontainers/ci/pull/210/files#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R58) following the release of 0.14 of `tfx-cli` (as per https://github.com/microsoft/tfs-cli/issues/427)

