### PR TITLE
Use version 0 to allow for breaking CLI changes in the future.

### DIFF
--- a/common/src/dev-container-cli.ts
+++ b/common/src/dev-container-cli.ts
@@ -5,7 +5,7 @@ import {env} from 'process';
 import {promisify} from 'util';
 import {ExecFunction} from './exec';
 
-const cliVersion = "latest"; // Use 'latest' to get latest CLI version, or pin to specific version e.g. '0.14.1' if required
+const cliVersion = "0"; // Use 'latest' to get latest CLI version, or pin to specific version e.g. '0.14.1' if required
 
 export interface DevContainerCliError {
   outcome: 'error';


### PR DESCRIPTION
Related: https://github.com/devcontainers/ci/issues/223