### PR TITLE
Update QEMU and Buildx steps to resolve Node 16 deprecation warning

### DIFF
--- a/.github/workflows/ci_common.yml
+++ b/.github/workflows/ci_common.yml
@@ -957,10 +957,10 @@ jobs:
           ref: ${{ inputs.prRef }}
 
       - name: Set up QEMU for multi-architecture builds
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # This can be omitted once runner images have a version of Skopeo > 1.4.1
       # See https://github.com/containers/skopeo/issues/1874 (and https://github.com/devcontainers/ci/issues/191#issuecomment-1416384710)
@@ -1057,10 +1057,10 @@ jobs:
           push: always
 
       - name: Set up QEMU for multi-architecture builds
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Install updated Skopeo
         # This can be omitted once runner images have a version of Skopeo > 1.4.1

--- a/docs/multi-platform-builds.md
+++ b/docs/multi-platform-builds.md
@@ -25,9 +25,9 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@v3
       - name: Set up QEMU for multi-architecture builds
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Setup Docker buildx for multi-architecture builds
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           use: true
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
`v2` of both these is now throwing a deprecation warning about it's use of Node 16. `v3` is a drop-in replacement in both these instances and resolves this warning. Updated in both workflows and documentation.